### PR TITLE
Remove unnecessary Func<> syntax

### DIFF
--- a/Business/Repository/Doctor/DoctorRepository.cs
+++ b/Business/Repository/Doctor/DoctorRepository.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Business.Dto.Doctors;
@@ -18,7 +18,7 @@ namespace Business.Repository.Doctor
             "LastName", "Photo", "Specialty"
         };
 
-        private Func<CMS.DocumentEngine.Types.MedioClinic.Doctor, DoctorDto> DoctorDtoSelect => doctor => new DoctorDto()
+        private DoctorDto DoctorDtoSelect(CMS.DocumentEngine.Types.MedioClinic.Doctor doctor) => new DoctorDto()
         {
             NodeAlias = doctor.NodeAlias,
             NodeGuid = doctor.NodeGUID,


### PR DESCRIPTION
Linq .Select() can work with just a plain function, so removed the unnecessary bits.

Also, removed a funky character at the beginning of the file (at least, according to GitHub in the browser).

### Motivation

Removed unnecessary syntax. Feel free to close this PR if you feel it is too trivial to pull in.
